### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,4 +1,6 @@
 name: C/C++ CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DarkStarStrix/PyC/security/code-scanning/2](https://github.com/DarkStarStrix/PyC/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the shown workflow only checks out code and runs build/test commands (and does not appear to require write access to the repository or PRs), the minimal permission of `contents: read` is sufficient. This should be added at the top level of the workflow file (just after the `name:` line and before `on:`), so it applies to all jobs unless overridden.

**Steps:**
- Edit `.github/workflows/c-cpp.yml`.
- Add the following block after the `name: C/C++ CI` line:
  ```yaml
  permissions:
    contents: read
  ```
- No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
